### PR TITLE
travis: remove unnecessary Pkg.checkout, move Pkg.add("Coverage") to …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
     email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.checkout("BusinessDays"); Pkg.add("Coverage"); Pkg.test("BusinessDays"; coverage=true)'
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("BusinessDays"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("BusinessDays")); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("BusinessDays")); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'cd(Pkg.dir("BusinessDays")); using Coverage; Codecov.submit(Codecov.process_folder())'


### PR DESCRIPTION
…after_success

`Pkg.clone(pwd())` will use what travis has checked out, which is typically master or a release tag
