### PR TITLE
Remove 0.6 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
     - linux
 julia:
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+Compat 0.17

--- a/src/BusinessDays.jl
+++ b/src/BusinessDays.jl
@@ -9,6 +9,7 @@ Website: https://github.com/felipenoris/BusinessDays.jl
 module BusinessDays
 
 using Base.Dates
+using Compat
 
 # types.jl
 export

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,7 +2,7 @@
 """
 *Abstract* type for Holiday Calendars.
 """
-abstract HolidayCalendar
+@compat abstract type HolidayCalendar; end
 
 """
 Data structure for calendar cache.


### PR DESCRIPTION
cc: @felipenoris 

This requires a dependency on Compat to keep 0.5 support