### PR TITLE
Make sure constructor delegation works as intended

### DIFF
--- a/src/bdays.jl
+++ b/src/bdays.jl
@@ -92,7 +92,7 @@ function advancebdays(hc::HolidayCalendar, dt::Date, bdays_count::Int)
     return result
 end
 
-advancebdays(calendar, dt, bdays_count) = advancebdays(convert(HolidayCalendar,calendar), dt, bdays_count)
+advancebdays(calendar, dt, bdays_count) = advancebdays(convert(HolidayCalendar,calendar), convert(Data,dt), bdays_count)
 
 """
     bdays(calendar, dt0, dt1)


### PR DESCRIPTION
The pre-patch constructor casts one parameter into a type appropriate for the other constructor without casting the `date` into a Date type required by other constructor. This allows (and actually did) create an infinite loop from the general constructor to itself.