### PR TITLE
Added constant-time special case bdayscount for WeekendsOnly calendar

### DIFF
--- a/src/calendars/calendars.jl
+++ b/src/calendars/calendars.jl
@@ -8,6 +8,43 @@ Remember that `isbday` considers that Saturdays and Sundars are not business day
 """
 struct WeekendsOnly <: HolidayCalendar end
 isholiday(::WeekendsOnly, dt::Dates.Date) = false
+function bdayscount(::WeekendsOnly, dt0::Dates.Date, dt1::Dates.Date)
+    swapped = false
+    if (dt0 == dt1)
+        return 0
+    elseif (dt0 > dt1)
+        dt1, dt0 = dt0, dt1
+        swapped = true
+    end
+
+    count = 0
+    days = (dt1 - dt0).value
+    whole_weeks = div(days, 7)
+    count += whole_weeks * 5
+    
+    dt0 += Dates.Day(whole_weeks * 7)
+    
+    if (dt0 < dt1)
+        day_of_week = Dates.dayofweek(dt0)
+
+        while (dt0 < dt1)
+            if day_of_week < 6
+                count += 1
+            end
+            dt0 += Dates.Day(1)
+            day_of_week += 1
+            if (day_of_week == 8)
+                day_of_week = 1
+            end
+        end
+    end
+
+    if swapped
+        count = -count
+    end
+
+    count
+end
 
 """
 A calendar with no holidays and no weekends.


### PR DESCRIPTION
For the common case of excluding weekends, I added a ~constant time special case `bdayscount`, based off https://github.com/numpy/numpy/blob/464f79eb1d05bf938d16b49da1c39a4e02506fa3/numpy/core/src/multiarray/datetime_busday.c#L362

Tested against the old one for lots of random test cases and seems ok. Performance is improved significantly.