### PR TITLE
HolidayCalendar broadcast as scalar

### DIFF
--- a/src/calendars/calendars.jl
+++ b/src/calendars/calendars.jl
@@ -8,6 +8,43 @@ Remember that `isbday` considers that Saturdays and Sundars are not business day
 """
 struct WeekendsOnly <: HolidayCalendar end
 isholiday(::WeekendsOnly, dt::Dates.Date) = false
+function bdayscount(::WeekendsOnly, dt0::Dates.Date, dt1::Dates.Date)
+    swapped = false
+    if (dt0 == dt1)
+        return 0
+    elseif (dt0 > dt1)
+        dt1, dt0 = dt0, dt1
+        swapped = true
+    end
+
+    count = 0
+    days = (dt1 - dt0).value
+    whole_weeks = div(days, 7)
+    count += whole_weeks * 5
+    
+    dt0 += Dates.Day(whole_weeks * 7)
+    
+    if (dt0 < dt1)
+        day_of_week = Dates.dayofweek(dt0)
+
+        while (dt0 < dt1)
+            if day_of_week < 6
+                count += 1
+            end
+            dt0 += Dates.Day(1)
+            day_of_week += 1
+            if (day_of_week == 8)
+                day_of_week = 1
+            end
+        end
+    end
+
+    if swapped
+        count = -count
+    end
+
+    count
+end
 
 """
 A calendar with no holidays and no weekends.

--- a/src/holidaycalendar.jl
+++ b/src/holidaycalendar.jl
@@ -6,6 +6,8 @@ abstract type HolidayCalendar end
 
 Base.string(hc::HolidayCalendar) = string(typeof(hc))
 
+Base.broadcastable(hc::HolidayCalendar) = Ref(hc)
+
 function symtocalendar(sym::Symbol) :: HolidayCalendar
     if isdefined(BusinessDays, sym) && Core.eval(BusinessDays, sym) <: HolidayCalendar
         return Core.eval(BusinessDays, sym)()


### PR DESCRIPTION
This is necessary for stuff like `tobday.(WeekendsOnly(), Date(2010, 1, 1):Day(1):Date(2013, 1, 1))` to behave as expected.