### PR TITLE
Added fast path NullHolidayCalendar bdayscount

### DIFF
--- a/src/calendars/calendars.jl
+++ b/src/calendars/calendars.jl
@@ -58,6 +58,7 @@ struct NullHolidayCalendar <: HolidayCalendar end
 isholiday(::NullHolidayCalendar, dt::Dates.Date) = false
 isbday(::NullHolidayCalendar, dt::Dates.Date) = true
 bdays(::NullHolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) = dt1 - dt0
+bdayscount(::NullHolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) = (dt1 - dt0).value
 
 include("australia.jl")
 include("brazil.jl")

--- a/src/calendars/calendars.jl
+++ b/src/calendars/calendars.jl
@@ -59,6 +59,7 @@ isholiday(::NullHolidayCalendar, dt::Dates.Date) = false
 isbday(::NullHolidayCalendar, dt::Dates.Date) = true
 bdays(::NullHolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) = dt1 - dt0
 bdayscount(::NullHolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) = (dt1 - dt0).value
+listbdays(::NullHolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) = collect(dt0:Dates.Day(1):dt1)
 
 include("australia.jl")
 include("brazil.jl")


### PR DESCRIPTION
Was surprised to see that this was missing - it was previously falling back to the generic iteration based `bdayscount` and could take several microseconds - now it's basically zero cost.