### PR TITLE
Add Carter's funeral to US Special Closings

### DIFF
--- a/src/calendars/us.jl
+++ b/src/calendars/us.jl
@@ -116,6 +116,9 @@ function isholiday(::USNYSE, dt::Dates.Date)
 
     # Special Closings
     if (
+        # President Carter's funeral
+        dt == Dates.Date(2025, 1, 9)
+        ||
         # President George H.W. Bush's funeral
         dt == Dates.Date(2018,12,5)
         ||


### PR DESCRIPTION
https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx