### PR TITLE
Change `hash` function to use 2 argument version

### DIFF
--- a/src/calendars/australia.jl
+++ b/src/calendars/australia.jl
@@ -32,7 +32,7 @@ struct Australia <: HolidayCalendar
 end
 
 Base.:(==)(a1::Australia, a2::Australia) = a1.state == a2.state
-Base.hash(a::Australia) = hash(a.state)
+Base.hash(a::Australia, h::UInt) = hash(a.state, h)
 
 
 function isholiday(::AustraliaASX, dt::Dates.Date)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -15,7 +15,7 @@ mutable struct GenericHolidayCalendar <: HolidayCalendar
 end
 
 Base.:(==)(g1::GenericHolidayCalendar, g2::GenericHolidayCalendar) = g1.holidays == g2.holidays && g1.dtmin == g2.dtmin && g1.dtmax == g2.dtmax
-Base.hash(g::GenericHolidayCalendar) = hash(g.holidays) + hash(g.dtmin) + hash(g.dtmax)
+Base.hash(g::GenericHolidayCalendar, h::UInt) = hash(g.dtmax, hash(g.dtmin, hash(g.holidays, h)))
 
 """
     GenericHolidayCalendar(holidays, [dtmin], [dtmax], [_initcache_])


### PR DESCRIPTION
Some changes to the way `hash` is implemented in the package:

- Changes the `hash` function to use the 2 argument version as recommended in the [Julia docs](https://docs.julialang.org/en/v1/base/base/#Base.hash)
- Applies the `hash` function recursively
- Makes BusinessDays.jl free of invalidations (at least with Base)

Before:
```julia
julia> using SnoopCompileCore

julia> invs = @snoop_invalidations using BusinessDays
Precompiling BusinessDays finished.
  1 dependency successfully precompiled in 2 seconds
SnoopCompileCore.InvalidationLists(Any[], Any[MethodInstance for Base.hashindex(::Any, ::Int64), 1, MethodInstance for Base.rehash!(::Dict, ::Int64), 2, MethodInstance for Base.var"#sizehint!#303"(::Bool, ::typeof(sizehint!), ::Dict, ::Int64), 3, MethodInstance for sizehint!(::Dict, ::Int64), 4, MethodInstance for (::Type{Dict{_A, _B}} where {_A, _B})(::Tuple{Pair{String, String}, Vararg{Pair}}), 5  …  MethodInstance for Base.var"#showerror#822"(::Bool, ::typeof(showerror), ::IOContext{Base.TTY}, ::BoundsError, ::Vector{Base.StackTraces.StackFrame}), 3, MethodInstance for Core.kwcall(::@NamedTuple{backtrace::Bool}, ::typeof(showerror), ::IOContext{Base.TTY}, ::BoundsError, ::Vector{Base.StackTraces.StackFrame}), 4, MethodInstance for Base.var"#showerror#822"(::Bool, ::typeof(showerror), ::IOContext{Base.TTY}, ::MethodError, ::Vector{Base.StackTraces.StackFrame}), 3, MethodInstance for hash(::Any), "jl_method_table_insert", hash(a::BusinessDays.Australia) @ BusinessDays ~/code/original_code/BusinessDays.jl/src/calendars/australia.jl:35, "jl_method_table_insert"])

julia> using SnoopCompile, AbstractTrees

julia> trees = invalidation_trees(invs)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting hash(a::BusinessDays.Australia) @ BusinessDays ~/code/original_code/BusinessDays.jl/src/calendars/australia.jl:35 invalidated:
   backedges: 1: superseding hash(x) @ Base hashing.jl:28 with MethodInstance for hash(::Any) (1400 children)
```

After:
```julia
julia> using SnoopCompileCore

julia> invs = @snoop_invalidations using BusinessDays
Precompiling BusinessDays finished.
  1 dependency successfully precompiled in 2 seconds. 3 already precompiled.
SnoopCompileCore.InvalidationLists(Any[], Any[])

julia> using SnoopCompile, AbstractTrees

julia> trees = invalidation_trees(invs)
SnoopCompile.MethodInvalidations[]
```

@felipenoris Let me know if this looks good!