### PR TITLE
Move test_bdays functions outside of calendar_tests.jl

### DIFF
--- a/test/calendar_tests.jl
+++ b/test/calendar_tests.jl
@@ -102,22 +102,6 @@ end
 @test isbday("WeekendsOnly", Dates.Date(2016,9,25)) == false
 @test bdayscount(:WeekendsOnly, Dates.Date(2016,9,25), Dates.Date(2016,9,28)) == 2
 
-function test_bdays(cal, d0::Dates.Date, d1::Dates.Date, expected_result::Integer)
-    @test bdays(cal, d0, d1) == Dates.Day(expected_result)
-    if d0 != d1
-        @test bdays(cal, d1, d0) == Dates.Day(-expected_result)
-    end
-    nothing
-end
-
-function test_bdays(cal,
-        d0::Tuple{Int, Int, Int},
-        d1::Tuple{Int, Int, Int},
-        expected_result::Integer)
-
-    test_bdays(cal, Dates.Date(d0[1], d0[2], d0[3]), Dates.Date(d1[1], d1[2], d1[3]), expected_result)
-end
-
 test_bdays(:WeekendsOnly, (2016, 9, 25), (2016, 9, 28), 2)
 test_bdays(:WeekendsOnly, (2019, 8, 26), (2019, 9, 2), 5)
 test_bdays(:WeekendsOnly, (2019, 8, 26), (2019, 9, 3), 6)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,0 +1,15 @@
+function test_bdays(cal, d0::Dates.Date, d1::Dates.Date, expected_result::Integer)
+    @test bdays(cal, d0, d1) == Dates.Day(expected_result)
+    if d0 != d1
+        @test bdays(cal, d1, d0) == Dates.Day(-expected_result)
+    end
+    nothing
+end
+
+function test_bdays(cal,
+        d0::Tuple{Int, Int, Int},
+        d1::Tuple{Int, Int, Int},
+        expected_result::Integer)
+
+    test_bdays(cal, Dates.Date(d0[1], d0[2], d0[3]), Dates.Date(d1[1], d1[2], d1[3]), expected_result)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,9 @@ hc_canada       = BusinessDays.CanadaSettlement()
 # Calendar Tests
 ####################
 
+# Defines helper functions for some common tests 
+include("functions.jl")
+
 usecache = false
 include("calendar_tests.jl")
 


### PR DESCRIPTION
Since it gets included twice, a method redefinition warning is emitted:

```WARNING: Method definition test_bdays(Any, Dates.Date, Dates.Date, Integer) in module Main at /home/andrei/code/BusinessDays.jl/test/calendar_tests.jl:105 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition test_bdays(Any, Tuple{Int64, Int64, Int64}, Tuple{Int64, Int64, Int64}, Integer) in module Main at /home/andrei/code/BusinessDays.jl/test/calendar_tests.jl:113 overwritten on the same line (check for duplicate calls to `include`).```

You can close the pull request if this is intentional, thanks!