### PR TITLE
Clarify docs on counting convention

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -134,11 +134,11 @@ false
 julia> isbday(BusinessDays.USSettlement(), Date(2015, 1, 1))
 false
 
-# Adjust to next business day
+# Adjust to next business day (or return date if already a business day)
 julia> tobday(:USSettlement, Date(2015, 1, 1))
 2015-01-02
 
-# Adjust to last business day
+# Adjust to last business day (or return date if already a business day)
 julia> tobday(:USSettlement, Date(2015, 1, 1); forward = false)
 2014-12-31
 

--- a/src/bdays.jl
+++ b/src/bdays.jl
@@ -105,6 +105,13 @@ Counts the number of Business Days between `dt0` and `dt1`.
 Returns `Int`.
 
 Computation is always based on next Business Day if given dates are not Business Days.
+
+!!! note "Counting Convention"
+    The first Business Day is excluded from the count, e.g. if `dt0` and `dt1` 
+    are the same date, `bdayscount` will always return 0. This convention is 
+    different from [`listbdays`](@ref) which *is* inclusive. In our 
+    `dt0 == dt1` example, if the date is a Business Day then `listbdays` will 
+    return a 1-element Vector with that date.
 """
 function bdayscount(hc::HolidayCalendar, dt0::Dates.Date, dt1::Dates.Date) :: Int
     if _getcachestate(hc)

--- a/src/query.jl
+++ b/src/query.jl
@@ -17,11 +17,11 @@ listholidays(calendar, dt0::Dates.Date, dt1::Dates.Date) = listholidays(convert(
 """
     listbdays(calendar, dt0::Dates.Date, dt1::Dates.Date) → Vector{Dates.Date}
 
-Returns the list of business days between `dt0` and `dt1`.
+Returns the list of business days between `dt0` and `dt1` (inclusive).
 """
 function listbdays(hc::HolidayCalendar, dt0::Dates.Date, dt1::Dates.Date)
-    d = tobday(hc, min(dt0, dt1))
-    d1 = max(dt0, dt1)
+    d, d1 = minmax(dt0, dt1)
+    d = tobday(hc, d)
 
     # empty result
     if d > d1


### PR DESCRIPTION
Clarifies some of the documentation:
- Adds some clarification for `tobday` in the docs on adjusting to next business day
- Adds a note on counting convention in `bdayscount`
- Adds clarification that `listbdays` is inclusive of the start and end date
- Minor optimization on `listbdays` to use `minmax`

Closes #65 
Closes #66 