### PR TITLE
Add the BDay type with tests and docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -150,6 +150,10 @@ julia> advancebdays(:USSettlement, Date(2015, 1, 2), 1)
 julia> advancebdays(:USSettlement, Date(2015, 1, 2), -1)
 2014-12-31
 
+# We can use BDay type as a convenience for advancebdays
+julia> Date(2015, 1, 2) + BDay(5, :USNYSE)
+2015-01-09
+
 # counts the number of business days between dates
 julia> bdays(:USSettlement, Date(2014, 12, 31), Date(2015, 1, 5))
 2 days
@@ -174,6 +178,34 @@ julia> bdays(:USSettlement, [Date(2014,12,31),Date(2015,1,2)], [Date(2015,1,5),D
 ```
 
 See *runtests.jl* for more examples.
+
+## `BDay` Type
+
+As shown in the tutorial above, a `BDay <: Dates.DatePeriod` can be used for convenience. This is to try to replicate date arithmetic as done in `Dates`. Under the hood, the date arithmetic is based on `advancebdays` so results should be the same between the two. 
+
+!!! warning "Differences between `BDay` and `Day` style arithmetic"
+    Note that because `advancebdays` always returns a `Date`, there is a different behavior when comparing against how `Dates.Day` arithmetic is performed on non-`Date` types such as `DateTime`. 
+
+    ```julia
+    julia> using BusinessDays, Dates
+
+    julia> d = Day(5)
+    5 days
+
+    julia> bd = BDay(5, :USNYSE)
+    5 business days (USNYSE)
+
+    julia> dt = DateTime(2015, 1, 1, 12, 30)
+    2015-01-01T12:30:00
+
+    # Returns DateTime
+    julia> dt + d
+    2015-01-06T12:30:00
+
+    # Returns Date
+    julia> dt + bd
+    2025-01-09
+    ```
 
 ## Available Business Days Calendars
 

--- a/src/BusinessDays.jl
+++ b/src/BusinessDays.jl
@@ -12,7 +12,8 @@ import Dates
 export
     HolidayCalendar,
     CompositeHolidayCalendar,
-    GenericHolidayCalendar
+    GenericHolidayCalendar,
+    BDay
 
 # exported functions
 export
@@ -33,6 +34,7 @@ include("dateutils.jl")
 include("holidaycalendar.jl")
 include("bdayscache.jl")
 include("bdays.jl")
+include("bday.jl")
 include("bdaysvecfun.jl")
 include("composite.jl")
 include("query.jl")

--- a/src/bday.jl
+++ b/src/bday.jl
@@ -1,0 +1,235 @@
+
+"""
+    BDay{C<:HolidayCalendar} <: Dates.DatePeriod
+
+Represents a business day period relative to a specific holiday calendar.
+
+Unlike `Dates.Day` which represents calendar days, `BDay` represents business
+days that skip weekends and holidays according to the specified calendar.
+
+# Constructors
+- `BDay(value, calendar::HolidayCalendar)`
+- `BDay(value, calendar::Symbol)` - e.g., `BDay(5, :USNYSE)`
+- `BDay(value, calendar::AbstractString)` - e.g., `BDay(5, "USNYSE")`
+
+# Examples
+```jldoctest
+julia> using BusinessDays, Dates
+
+julia> bd = BDay(5, :USNYSE)
+5 business days (USNYSE)
+
+julia> Dates.value(bd)
+5
+
+julia> Date(2023, 1, 2) + BDay(5, :USNYSE)  # Advance 5 business days
+2023-01-10
+
+julia> BDay(5, :USNYSE) + BDay(3, :USNYSE)  # BDay arithmetic
+8 business days (USNYSE)
+```
+
+!!! warning "Mixed Calendar Operations"
+    Operations between BDay periods with different calendars will throw
+    an `ArgumentError`. This is intentional since combining business days
+    from different calendars produces ambiguous results.
+"""
+struct BDay{C<:HolidayCalendar} <: Dates.DatePeriod
+    value::Int64
+    calendar::C
+
+    function BDay(x, calendar::C) where {C<:HolidayCalendar}
+        new{C}(_align_value(x), _align_calendar(calendar))
+    end
+end
+
+_align_value(x) = convert(Int64, x)
+_align_value(x::AbstractString) = Base.parse(Int64, x)
+_align_calendar(c) = c
+_align_calendar(c::Symbol) = convert(HolidayCalendar, c)
+_align_calendar(c::AbstractString) = convert(HolidayCalendar, c)
+
+# Convenience constructors
+BDay(value, calendar::Symbol) = BDay(value, convert(HolidayCalendar, calendar))
+BDay(value, calendar::AbstractString) = BDay(value, convert(HolidayCalendar, calendar))
+
+# Accessor functions
+
+"""
+    calendar(bd::BDay) -> HolidayCalendar
+
+Returns the holiday calendar associated with this BDay period.
+"""
+calendar(bd::BDay) = bd.calendar
+
+# Equality and hashing
+Base.:(==)(bd1::BDay, bd2::BDay) = Dates.value(bd1) == Dates.value(bd2) && calendar(bd1) == calendar(bd2)
+Base.hash(bd::BDay, h::UInt) = hash(calendar(bd), hash(Dates.value(bd), h))
+
+# Comparison (same calendar only)
+function Base.isless(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return Dates.value(bd1) < Dates.value(bd2)
+end
+
+function Base.isless(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+# Negation
+Base.:(-)(bd::BDay) = BDay(-Dates.value(bd), calendar(bd))
+
+# BDay + BDay (same calendar type)
+function Base.:(+)(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(Dates.value(bd1) + Dates.value(bd2), calendar(bd1))
+end
+
+# BDay + BDay (different calendar types - always error)
+function Base.:(+)(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+# BDay - BDay (same calendar type)
+function Base.:(-)(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(Dates.value(bd1) - Dates.value(bd2), calendar(bd1))
+end
+
+# BDay - BDay (different calendar types - always error)
+function Base.:(-)(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+# Scalar multiplication
+Base.:(*)(bd::BDay, x::Real) = BDay(Dates.value(bd) * x, calendar(bd))
+Base.:(*)(x::Real, bd::BDay) = bd * x
+
+# Division
+Base.:(/)(bd::BDay, x::Real) = BDay(Dates.value(bd) / x, calendar(bd))
+function Base.div(bd1::BDay{C}, bd2::BDay{C}, r::RoundingMode) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    div(Dates.value(bd1), Dates.value(bd2), r)
+end
+function Base.div(bd1::BDay, bd2::BDay, ::RoundingMode)
+    throw(ArgumentError(LazyString(
+        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+Base.div(bd::BDay, x::Real, r::RoundingMode) = BDay(div(Dates.value(bd), Int64(x), r), calendar(bd))
+
+# mod/rem between BDays (same calendar only)
+function Base.mod(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(mod(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
+end
+
+function Base.mod(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+Base.mod(bd::BDay, x::Real) = BDay(mod(Dates.value(bd), Int64(x)), calendar(bd))
+
+function Base.rem(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(rem(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
+end
+
+function Base.rem(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+Base.rem(bd::BDay, x::Real) = BDay(rem(Dates.value(bd), Int64(x)), calendar(bd))
+
+# Absolute value
+Base.abs(bd::BDay) = BDay(abs(Dates.value(bd)), calendar(bd))
+
+# zero - need custom implementation since BDay requires a calendar
+Base.zero(bd::BDay) = BDay(0, calendar(bd))
+
+# gcd/lcm between BDays (same calendar only)
+function Base.gcd(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(gcd(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
+end
+
+function Base.gcd(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+function Base.lcm(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    return BDay(lcm(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
+end
+
+function Base.lcm(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+function Base.gcdx(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar} 
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
+        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    g, x, y = gcdx(Dates.value(bd1), Dates.value(bd2))
+    return (BDay(g, calendar(bd1)), x, y)
+end
+function Base.gcdx(bd1::BDay, bd2::BDay)
+    throw(ArgumentError(LazyString(
+        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+end
+
+# Display - need to define both show and print to override Dates.Period defaults
+# Helper to get a clean calendar name for display
+_calendar_name(hc::HolidayCalendar) = string(typeof(hc).name.name)
+
+# The show method for compact representation (e.g., in arrays)
+function Base.show(io::IO, bd::BDay)
+    print(io, "BDay(", Dates.value(bd), ", ", _calendar_name(calendar(bd)), ")")
+end
+
+# For text/plain MIME (REPL display)
+function Base.show(io::IO, ::MIME"text/plain", bd::BDay)
+    v = Dates.value(bd)
+    print(io, v, " business day")
+    abs(v) != 1 && print(io, "s")
+    print(io, " (", _calendar_name(calendar(bd)), ")")
+end
+
+# Override Dates._units to avoid MethodError when print(::Period) is called
+Dates._units(bd::BDay) = " business day" * (abs(Dates.value(bd)) == 1 ? "" : "s")
+
+# Broadcasting support
+Base.broadcastable(bd::BDay) = Ref(bd)
+
+# Date + BDay
+Base.:(+)(dt::Dates.Date, bd::BDay) = advancebdays(calendar(bd), dt, Dates.value(bd))
+
+# BDay + Date (commutativity)
+Base.:(+)(bd::BDay, dt::Dates.Date) = dt + bd
+
+# Date - BDay
+Base.:(-)(dt::Dates.Date, bd::BDay) = advancebdays(calendar(bd), convert(Dates.Date, dt), -Dates.value(bd))
+
+# DateTime + BDay returns a Date, keep consistent with rest of package
+function Base.:(+)(dt::Dates.DateTime, bd::BDay)
+    convert(Dates.Date, dt) + bd
+end
+
+Base.:(+)(bd::BDay, dt::Dates.DateTime) = dt + bd
+
+function Base.:(-)(dt::Dates.DateTime, bd::BDay)
+    convert(Dates.Date, dt) - bd
+end

--- a/src/bday.jl
+++ b/src/bday.jl
@@ -68,14 +68,14 @@ Base.hash(bd::BDay, h::UInt) = hash(calendar(bd), hash(Dates.value(bd), h))
 
 # Comparison (same calendar only)
 function Base.isless(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return Dates.value(bd1) < Dates.value(bd2)
 end
 
 function Base.isless(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compare BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 # Negation
@@ -83,28 +83,28 @@ Base.:(-)(bd::BDay) = BDay(-Dates.value(bd), calendar(bd))
 
 # BDay + BDay (same calendar type)
 function Base.:(+)(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(Dates.value(bd1) + Dates.value(bd2), calendar(bd1))
 end
 
 # BDay + BDay (different calendar types - always error)
 function Base.:(+)(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot add BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 # BDay - BDay (same calendar type)
 function Base.:(-)(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(Dates.value(bd1) - Dates.value(bd2), calendar(bd1))
 end
 
 # BDay - BDay (different calendar types - always error)
 function Base.:(-)(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot subtract BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 # Scalar multiplication
@@ -114,39 +114,39 @@ Base.:(*)(x::Real, bd::BDay) = bd * x
 # Division
 Base.:(/)(bd::BDay, x::Real) = BDay(Dates.value(bd) / x, calendar(bd))
 function Base.div(bd1::BDay{C}, bd2::BDay{C}, r::RoundingMode) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     div(Dates.value(bd1), Dates.value(bd2), r)
 end
 function Base.div(bd1::BDay, bd2::BDay, ::RoundingMode)
-    throw(ArgumentError(LazyString(
-        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute div of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 Base.div(bd::BDay, x::Real, r::RoundingMode) = BDay(div(Dates.value(bd), Int64(x), r), calendar(bd))
 
 # mod/rem between BDays (same calendar only)
 function Base.mod(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(mod(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
 end
 
 function Base.mod(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute mod of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 Base.mod(bd::BDay, x::Real) = BDay(mod(Dates.value(bd), Int64(x)), calendar(bd))
 
 function Base.rem(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(rem(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
 end
 
 function Base.rem(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute rem of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 Base.rem(bd::BDay, x::Real) = BDay(rem(Dates.value(bd), Int64(x)), calendar(bd))
@@ -159,36 +159,36 @@ Base.zero(bd::BDay) = BDay(0, calendar(bd))
 
 # gcd/lcm between BDays (same calendar only)
 function Base.gcd(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(gcd(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
 end
 
 function Base.gcd(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute gcd of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 function Base.lcm(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     return BDay(lcm(Dates.value(bd1), Dates.value(bd2)), calendar(bd1))
 end
 
 function Base.lcm(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute lcm of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
-function Base.gcdx(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar} 
-    calendar(bd1) == calendar(bd2) || throw(ArgumentError(LazyString(
-        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+function Base.gcdx(bd1::BDay{C}, bd2::BDay{C}) where {C<:HolidayCalendar}
+    calendar(bd1) == calendar(bd2) || throw(ArgumentError(
+        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
     g, x, y = gcdx(Dates.value(bd1), Dates.value(bd2))
     return (BDay(g, calendar(bd1)), x, y)
 end
 function Base.gcdx(bd1::BDay, bd2::BDay)
-    throw(ArgumentError(LazyString(
-        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))")))
+    throw(ArgumentError(
+        "Cannot compute gcdx of BDay periods with different calendars: $(calendar(bd1)) vs $(calendar(bd2))"))
 end
 
 # Display - need to define both show and print to override Dates.Period defaults

--- a/test/bday_tests.jl
+++ b/test/bday_tests.jl
@@ -321,11 +321,6 @@
         @test sign(bd_pos) == 1
         @test sign(bd_neg) == -1
         @test sign(bd_zero) == 0
-
-        # signbit returns Bool
-        @test signbit(bd_pos) == false
-        @test signbit(bd_neg) == true
-        @test signbit(bd_zero) == false
     end
 
     @testset "one (Inherited from Period)" begin

--- a/test/bday_tests.jl
+++ b/test/bday_tests.jl
@@ -1,0 +1,389 @@
+@testset "BDay Type" begin
+
+    @testset "Construction" begin
+        # From HolidayCalendar instance
+        bd1 = BDay(5, BusinessDays.USNYSE())
+        @test Dates.value(bd1) == 5
+        @test BusinessDays.calendar(bd1) == BusinessDays.USNYSE()
+
+        # From Symbol
+        bd2 = BDay(3, :USNYSE)
+        @test Dates.value(bd2) == 3
+        @test BusinessDays.calendar(bd2) == BusinessDays.USNYSE()
+
+        # From String
+        bd3 = BDay(-2, "Brazil")
+        @test Dates.value(bd3) == -2
+        @test BusinessDays.calendar(bd3) == BusinessDays.BRSettlement()
+
+        # Zero value
+        bd4 = BDay(0, :USNYSE)
+        @test Dates.value(bd4) == 0
+
+        # Negative value
+        bd5 = BDay(-10, :USNYSE)
+        @test Dates.value(bd5) == -10
+
+        # Using string values
+        bd6 = BDay("100", :USNYSE)
+        @test Dates.value(bd6) == 100
+        bd7 = BDay("-500", :USNYSE)
+        @test Dates.value(bd7) == -500
+
+        # Invalid calendar should throw
+        @test_throws Exception BDay(5, :InvalidCalendar)
+    end
+
+    @testset "Type Hierarchy" begin
+        bd = BDay(5, :USNYSE)
+
+        @test bd isa Dates.DatePeriod
+        @test bd isa Dates.Period
+        @test bd isa BDay{BusinessDays.USNYSE}
+    end
+
+    @testset "Equality and Hashing" begin
+        bd1 = BDay(5, :USNYSE)
+        bd2 = BDay(5, :USNYSE)
+        bd3 = BDay(5, :Brazil)
+        bd4 = BDay(3, :USNYSE)
+
+        @test bd1 == bd2
+        @test bd1 != bd3  # Different calendar
+        @test bd1 != bd4  # Different value
+
+        @test hash(bd1) == hash(bd2)
+        @test hash(bd1) != hash(bd3)
+
+        # Works in Set
+        s = Set([bd1, bd2, bd3])
+        @test length(s) == 2
+
+        # Works in Dict
+        d = Dict(bd1 => "nyse5")
+        @test d[bd2] == "nyse5"
+    end
+
+    @testset "Comparison" begin
+        bd1 = BDay(5, :USNYSE)
+        bd2 = BDay(3, :USNYSE)
+        bd3 = BDay(5, :Brazil)
+
+        @test bd2 < bd1
+        @test bd1 > bd2
+        @test bd1 >= bd1
+        @test bd2 <= bd1
+
+        # Different calendars should throw
+        @test_throws ArgumentError bd1 < bd3
+        @test_throws ArgumentError bd1 > bd3
+    end
+
+    @testset "Negation" begin
+        bd = BDay(5, :USNYSE)
+        neg_bd = -bd
+
+        @test Dates.value(neg_bd) == -5
+        @test BusinessDays.calendar(neg_bd) == BusinessDays.USNYSE()
+        @test -(-bd) == bd
+    end
+
+    @testset "BDay Arithmetic - Same Calendar" begin
+        bd1 = BDay(5, :USNYSE)
+        bd2 = BDay(3, :USNYSE)
+
+        # Addition
+        result = bd1 + bd2
+        @test Dates.value(result) == 8
+        @test BusinessDays.calendar(result) == BusinessDays.USNYSE()
+
+        # Subtraction
+        result = bd1 - bd2
+        @test Dates.value(result) == 2
+        @test BusinessDays.calendar(result) == BusinessDays.USNYSE()
+
+        # With negative
+        bd_neg = BDay(-2, :USNYSE)
+        @test Dates.value(bd1 + bd_neg) == 3
+    end
+
+    @testset "BDay Arithmetic - Different Calendar (Error)" begin
+        bd_nyse = BDay(5, :USNYSE)
+        bd_brazil = BDay(3, :Brazil)
+
+        @test_throws ArgumentError bd_nyse + bd_brazil
+        @test_throws ArgumentError bd_nyse - bd_brazil
+    end
+
+    @testset "BDay Arithmetic - Parametric Calendar Same Type Different Instance" begin
+        # Australia(:ACT) and Australia(:NSW) are the same type but different instances
+        bd_act = BDay(5, BusinessDays.Australia(:ACT))
+        bd_nsw = BDay(3, BusinessDays.Australia(:NSW))
+
+        # Should throw because they are different calendars even though same type
+        @test_throws ArgumentError bd_act + bd_nsw
+        @test_throws ArgumentError bd_act - bd_nsw
+        @test_throws ArgumentError bd_act < bd_nsw
+
+        # Same instance should work
+        bd_act2 = BDay(3, BusinessDays.Australia(:ACT))
+        @test Dates.value(bd_act + bd_act2) == 8
+    end
+
+    @testset "Scalar Multiplication" begin
+        bd = BDay(5, :USNYSE)
+
+        # Integer multiplication
+        @test Dates.value(bd * 2) == 10
+        @test Dates.value(2 * bd) == 10
+        @test Dates.value(bd * -1) == -5
+
+        # Calendar preserved
+        @test BusinessDays.calendar(bd * 3) == BusinessDays.USNYSE()
+    end
+
+    @testset "Division" begin
+        bd = BDay(10, :USNYSE)
+
+        # Exact division with /
+        @test Dates.value(bd / 2) == 5
+        @test BusinessDays.calendar(bd / 2) == BusinessDays.USNYSE()
+
+        # Inexact division throws InexactError (consistent with Dates.Day)
+        @test_throws InexactError bd / 3
+
+        # Integer division with div
+        @test Dates.value(div(bd, 2)) == 5
+        @test Dates.value(div(bd, 3)) == 3
+        @test BusinessDays.calendar(div(bd, 2)) == BusinessDays.USNYSE()
+
+        # Floor division with fld
+        @test Dates.value(fld(bd, 3)) == 3
+        @test Dates.value(fld(BDay(-10, :USNYSE), 3)) == -4  # fld rounds toward -Inf
+        @test BusinessDays.calendar(fld(bd, 3)) == BusinessDays.USNYSE()
+    end
+
+    @testset "Modulo and Remainder" begin
+        bd1 = BDay(10, :USNYSE)
+        bd2 = BDay(3, :USNYSE)
+
+        # mod
+        @test Dates.value(mod(bd1, bd2)) == 1
+        @test BusinessDays.calendar(mod(bd1, bd2)) == BusinessDays.USNYSE()
+
+        # rem
+        @test Dates.value(rem(bd1, bd2)) == 1
+        @test BusinessDays.calendar(rem(bd1, bd2)) == BusinessDays.USNYSE()
+
+        # mod vs rem with negative values
+        bd_neg = BDay(-10, :USNYSE)
+        @test Dates.value(mod(bd_neg, bd2)) == 2   # mod result has sign of divisor
+        @test Dates.value(rem(bd_neg, bd2)) == -1  # rem result has sign of dividend
+
+        # Different calendars should throw
+        bd_brazil = BDay(3, :Brazil)
+        @test_throws ArgumentError mod(bd1, bd_brazil)
+        @test_throws ArgumentError rem(bd1, bd_brazil)
+
+        # mod and rem with Real (scalar)
+        @test Dates.value(mod(bd1, 3)) == 1
+        @test BusinessDays.calendar(mod(bd1, 3)) == BusinessDays.USNYSE()
+        @test Dates.value(rem(bd1, 3)) == 1
+        @test BusinessDays.calendar(rem(bd1, 3)) == BusinessDays.USNYSE()
+
+        # mod vs rem with negative BDay and Real divisor
+        @test Dates.value(mod(bd_neg, 3)) == 2   # mod result has sign of divisor
+        @test Dates.value(rem(bd_neg, 3)) == -1  # rem result has sign of dividend
+    end
+
+    @testset "Absolute Value" begin
+        bd_pos = BDay(5, :USNYSE)
+        bd_neg = BDay(-5, :USNYSE)
+        bd_zero = BDay(0, :USNYSE)
+
+        @test Dates.value(abs(bd_pos)) == 5
+        @test Dates.value(abs(bd_neg)) == 5
+        @test Dates.value(abs(bd_zero)) == 0
+
+        @test BusinessDays.calendar(abs(bd_neg)) == BusinessDays.USNYSE()
+    end
+
+    @testset "Date + BDay" begin
+        # Tuesday Jan 3, 2023 (Jan 2 is NYSE holiday - New Year observed)
+        dt = Dates.Date(2023, 1, 3)  # Tuesday - first business day of 2023
+        bd = BDay(5, :USNYSE)
+        result = dt + bd
+
+        # Jan 3 + 5 business days = Jan 10 (skipping weekend Jan 7-8)
+        @test result == Dates.Date(2023, 1, 10)
+
+        # Verify same as advancebdays
+        @test result == advancebdays(:USNYSE, dt, 5)
+
+        # Commutativity
+        @test bd + dt == dt + bd
+    end
+
+    @testset "Date - BDay" begin
+        dt = Dates.Date(2023, 1, 10)  # Tuesday
+        bd = BDay(5, :USNYSE)
+        result = dt - bd
+
+        # Should go back to Tuesday Jan 3
+        @test result == Dates.Date(2023, 1, 3)
+
+        # Verify same as advancebdays with negative
+        @test result == advancebdays(:USNYSE, dt, -5)
+    end
+
+    @testset "Date Arithmetic with Holidays" begin
+        # Test around MLK Day 2023 (Monday Jan 16 - NYSE closed)
+        dt = Dates.Date(2023, 1, 13)  # Friday before MLK Day
+        bd = BDay(1, :USNYSE)
+
+        # 1 business day after Friday should skip weekend AND Monday holiday
+        result = dt + bd
+        @test result == Dates.Date(2023, 1, 17)  # Tuesday
+
+        # Going backward
+        dt2 = Dates.Date(2023, 1, 17)  # Tuesday after MLK Day
+        result2 = dt2 - BDay(1, :USNYSE)
+        @test result2 == Dates.Date(2023, 1, 13)  # Friday before
+    end
+
+    @testset "BDay with Zero Value" begin
+        # Use Jan 3, 2023 which is definitely a business day (Jan 2 is NYSE holiday)
+        dt = Dates.Date(2023, 1, 3)  # Tuesday (business day)
+        bd_zero = BDay(0, :USNYSE)
+
+        @test dt + bd_zero == dt
+        @test dt - bd_zero == dt
+
+        # On a weekend, should move to next business day (tobday behavior)
+        dt_sat = Dates.Date(2023, 1, 7)  # Saturday
+        result = dt_sat + bd_zero
+        @test result == Dates.Date(2023, 1, 9)  # Monday
+    end
+
+    @testset "Show/Display" begin
+        bd1 = BDay(1, :USNYSE)
+        bd5 = BDay(5, :USNYSE)
+        bd_neg = BDay(-3, :Brazil)
+
+        # string() uses print() which uses Dates._units
+        @test occursin("1 business day", string(bd1))
+        @test occursin("5 business days", string(bd5))
+        @test occursin("-3 business days", string(bd_neg))
+
+        # repr uses show() which gives compact form
+        @test occursin("BDay", repr(bd5))
+        @test occursin("USNYSE", repr(bd1))
+
+        # Test that the MIME text/plain show works (used in REPL) - includes calendar
+        io = IOBuffer()
+        show(io, MIME"text/plain"(), bd1)
+        s1 = String(take!(io))
+        @test occursin("1 business day", s1)
+        @test occursin("USNYSE", s1)
+
+        show(io, MIME"text/plain"(), bd5)
+        s5 = String(take!(io))
+        @test occursin("5 business days", s5)
+    end
+
+    @testset "Broadcasting" begin
+        # Use dates that are definitely business days (Jan 3-5, 2023)
+        dates = [Dates.Date(2023, 1, 3), Dates.Date(2023, 1, 4), Dates.Date(2023, 1, 5)]
+        bd = BDay(1, :USNYSE)
+
+        results = dates .+ bd
+
+        @test results[1] == Dates.Date(2023, 1, 4)
+        @test results[2] == Dates.Date(2023, 1, 5)
+        @test results[3] == Dates.Date(2023, 1, 6)
+    end
+
+    @testset "DateTime + BDay" begin
+        dt = Dates.DateTime(2023, 1, 3, 12, 30, 0)
+        bd = BDay(5, :USNYSE)
+
+        @test dt + bd == Dates.Date(2023, 1, 10)
+        @test bd + dt == Dates.Date(2023, 1, 10)
+        @test dt - bd == Dates.Date(2022, 12, 23)
+    end
+
+    @testset "Sign Operations (Inherited from Period)" begin
+        bd_pos = BDay(5, :USNYSE)
+        bd_neg = BDay(-5, :USNYSE)
+        bd_zero = BDay(0, :USNYSE)
+
+        # sign returns Int
+        @test sign(bd_pos) == 1
+        @test sign(bd_neg) == -1
+        @test sign(bd_zero) == 0
+
+        # signbit returns Bool
+        @test signbit(bd_pos) == false
+        @test signbit(bd_neg) == true
+        @test signbit(bd_zero) == false
+    end
+
+    @testset "one (Inherited from Period)" begin
+        bd = BDay(5, :USNYSE)
+
+        # one returns the multiplicative identity (1), not BDay(1, ...)
+        @test one(bd) == 1
+        @test one(typeof(bd)) == 1
+    end
+
+    @testset "zero and iszero" begin
+        bd = BDay(5, :USNYSE)
+        bd_zero = BDay(0, :USNYSE)
+
+        # zero requires an instance (needs calendar)
+        @test Dates.value(zero(bd)) == 0
+        @test BusinessDays.calendar(zero(bd)) == BusinessDays.USNYSE()
+
+        # iszero
+        @test iszero(bd_zero) == true
+        @test iszero(bd) == false
+    end
+
+    @testset "GCD and LCM" begin
+        bd1 = BDay(10, :USNYSE)
+        bd2 = BDay(4, :USNYSE)
+
+        # gcd
+        @test Dates.value(gcd(bd1, bd2)) == 2
+        @test BusinessDays.calendar(gcd(bd1, bd2)) == BusinessDays.USNYSE()
+
+        # lcm
+        @test Dates.value(lcm(bd1, bd2)) == 20
+        @test BusinessDays.calendar(lcm(bd1, bd2)) == BusinessDays.USNYSE()
+
+        # gcdx
+        (g, x, y) = gcdx(bd1, bd2)
+        @test g == BDay(2, :USNYSE)
+        @test (x, y) == (1, -2)
+
+        # Different calendars should throw
+        bd_brazil = BDay(4, :Brazil)
+        @test_throws ArgumentError gcd(bd1, bd_brazil)
+        @test_throws ArgumentError lcm(bd1, bd_brazil)
+    end
+
+    @testset "BDay / BDay and BDay ÷ BDay (Inherited from Period)" begin
+        bd1 = BDay(10, :USNYSE)
+        bd2 = BDay(2, :USNYSE)
+        bd3 = BDay(3, :USNYSE)
+
+        # Division between BDays returns Float64 (inherited)
+        @test bd1 / bd2 == 5.0
+        @test bd1 / bd3 ≈ 10/3
+
+        # Integer division between BDays returns Int (inherited)
+        @test bd1 ÷ bd2 == 5
+        @test bd1 ÷ bd3 == 3
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,3 +272,8 @@ cal_dict = Dict(gen_1 => "hey")
 
 # Broadcast
 @test BusinessDays.tobday.(BusinessDays.WeekendsOnly(), [Dates.Date(2019, 8, 30), Dates.Date(2019, 8, 31), Dates.Date(2019, 9, 1), Dates.Date(2019, 9, 2)]) == [Dates.Date(2019, 8, 30), Dates.Date(2019, 9, 2), Dates.Date(2019, 9, 2), Dates.Date(2019, 9, 2)]
+
+#########################
+# BDay Type Tests
+#########################
+include("bday_tests.jl")


### PR DESCRIPTION
Adds the `BDay` type as suggested in #53. 

```julia
julia> using BusinessDays, Dates

julia> bd = BDay(5, :USNYSE)
5 business days (USNYSE)

julia> Date(2025, 1, 1)  + bd
2025-01-10
```

The `BDay` type uses `advancebdays` under the hood so it should behave identically. 

I'm also subtyping on `Dates.DatePeriod` so I tried to implement as many of the `Period` functions from the Dates stdlib as I could, e.g. with `gcd`:

```julia
julia> gcd(BDay(15, :USNYSE), BDay(21, :USNYSE))
3 business days (USNYSE)  
```

These functions will throw an error if the calendars are not the same:

```julia
julia> gcd(BDay(15, :USNYSE), BDay(21, :USSettlement))
ERROR: ArgumentError: Cannot compute gcd of BDay periods with different calendars: BusinessDays.USNYSE() vs BusinessDays.USSettlement()
Stacktrace:
 [1] gcd(bd1::BDay{BusinessDays.USNYSE}, bd2::BDay{BusinessDays.USSettlement})
   @ BusinessDays ~/code/BusinessDays.jl/src/bday.jl:165
 [2] top-level scope
   @ REPL[12]:1
 [3] top-level scope
   @ REPL:1
```

Developed with support from Claude Code AI.

@felipenoris let me know if this looks okay, or if you'd prefer this type to be outside `BusinessDays.jl`, I could put it in it's package instead.

Closes #53