### PR TITLE
Use Dates.yearmonthday function where appropriate

### DIFF
--- a/src/calendars/australia.jl
+++ b/src/calendars/australia.jl
@@ -36,9 +36,7 @@ Base.hash(a::Australia, h::UInt) = hash(a.state, h)
 
 
 function isholiday(::AustraliaASX, dt::Dates.Date)
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
     easter_sunday = BusinessDays.easter_date(Dates.Year(yy))
     is_australian_national_holiday(dt, yy, mm, dd, easter_sunday) && return true
     mm == 6 && Dates.dayofweek(dt) == Dates.Mon && Dates.dayofweekofmonth(dt) == 2 && return true # Queen's Birthday holiday (2nd Monday of June)
@@ -47,9 +45,7 @@ end
 
 
 function isholiday(cal::Australia, dt::Dates.Date)
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
     easter_sunday = BusinessDays.easter_date(Dates.Year(yy))
     is_australian_national_holiday(dt, yy, mm, dd, easter_sunday) && return true
     is_australian_state_holiday(Val{cal.state}, dt, yy, mm, dd, easter_sunday)

--- a/src/calendars/brazil.jl
+++ b/src/calendars/brazil.jl
@@ -11,9 +11,7 @@ const BrazilB3 = BrazilExchange
 # Brazilian Banking Holidays
 function isholiday(::BRSettlement, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
 
     # Bisection
     if mm >= 8
@@ -81,9 +79,7 @@ function isholiday(::BRSettlement, dt::Dates.Date)
 end
 
 function isholiday(::BrazilExchange, dt::Dates.Date)
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
 
     if (
         # Aniversário de São Paulo

--- a/src/calendars/canada.jl
+++ b/src/calendars/canada.jl
@@ -12,9 +12,7 @@ struct CanadaTSX <: HolidayCalendar end
 
 function isholiday(::CanadaSettlement, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
     ww = Dates.dayofweek(dt)
 
     # Bisection
@@ -70,9 +68,7 @@ end
 
 function isholiday(::CanadaTSX, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
     ww = Dates.dayofweek(dt)
 
     # Bisection

--- a/src/calendars/germany.jl
+++ b/src/calendars/germany.jl
@@ -45,9 +45,7 @@ Return true if `dt` is a is a holiday in the German calender (`cal`), otherwise 
 """
 function isholiday(cal::DE, dt::Dates.Date)::Bool
     dt ≤ Dates.Date(1990, 10, 3) && return false # Only count holidays after German Reunification
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
     easter_sunday = BusinessDays.easter_date(Dates.Year(yy))
     is_common_german_holiday(dt, yy, mm, dd, easter_sunday) && return true
     is_german_state_holiday(Val{cal.state}, dt, yy, mm, dd, easter_sunday)

--- a/src/calendars/target.jl
+++ b/src/calendars/target.jl
@@ -7,9 +7,7 @@ const TARGET2 = TARGET
 const EuroZone = TARGET
 
 function isholiday(::TARGET, dt::Dates.Date)
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
 
     # Bisection
     if mm < 8

--- a/src/calendars/uk.jl
+++ b/src/calendars/uk.jl
@@ -8,9 +8,7 @@ const UnitedKingdom = UKSettlement
 # England and Wales Banking Holidays
 function isholiday(::UKSettlement, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm) = Dates.yearmonth(dt)
 
     # Bisection
     if mm >= 8

--- a/src/calendars/us.jl
+++ b/src/calendars/us.jl
@@ -19,9 +19,7 @@ struct USGovernmentBond <: HolidayCalendar end
 
 function isholiday(::USSettlement, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
 
     if (
             # New Year's Day
@@ -68,9 +66,7 @@ end
 
 function isholiday(::USNYSE, dt::Dates.Date)
 
-    yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
+    (yy, mm, dd) = Dates.yearmonthday(dt)
 
     dt_rata::Int = Dates.days(dt)
     e_rata::Int = easter_rata(Dates.Year(yy))
@@ -188,8 +184,6 @@ end
 function isholiday(::USGovernmentBond, dt::Dates.Date)
 
     yy = Dates.year(dt)
-    mm = Dates.month(dt)
-    dd = Dates.day(dt)
 
     dt_rata::Int = Dates.days(dt)
     e_rata::Int = easter_rata(Dates.Year(yy))


### PR DESCRIPTION
Use `Dates.yearmonthday` to simultaneously get the year, month, and day. This slightly improves performance:

Before:

```julia
julia> using BenchmarkTools

julia> using BusinessDays

julia> using Dates

julia> cal = BusinessDays.USSettlement();

julia> d = Date(2026, 1, 2);

julia> @btime isholiday($cal, $d);
  385.911 ns (0 allocations: 0 bytes)

julia> d = Date(2026, 1, 1);

julia> @btime isholiday($cal, $d);
  88.467 ns (0 allocations: 0 bytes)
```

After:

```julia
julia> d = Date(2026, 1, 2);

julia> @btime isholiday($cal, $d);
  348.192 ns (0 allocations: 0 bytes)

julia> d = Date(2026, 1, 1);

julia> @btime isholiday($cal, $d);
  50.441 ns (0 allocations: 0 bytes)
```